### PR TITLE
Fix stats page crash when URLs have no visits

### DIFF
--- a/app/[shortKey]/stats/page.tsx
+++ b/app/[shortKey]/stats/page.tsx
@@ -48,8 +48,11 @@ export default async function StatsPage({ params }: { params: { shortKey: string
 
   if (!stats) return null
 
-  // Get the latest visit
-  const latestVisit = stats.content.visits[stats.content.visits.length - 1]
+  // Get the latest visit if available
+  const latestVisit =
+    stats.content.visits.length > 0
+      ? stats.content.visits[stats.content.visits.length - 1]
+      : null
 
   return (
     <div className="container mx-auto py-10">

--- a/components/cards/LastVisit.tsx
+++ b/components/cards/LastVisit.tsx
@@ -3,10 +3,23 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { UrlVisitInfo } from '@/types/analytics'
 
 interface LastVisitProps {
-  visit: UrlVisitInfo
+  visit: UrlVisitInfo | null
 }
 
 export function LastVisit({ visit }: LastVisitProps) {
+  if (!visit) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Last Visit</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">No visits yet.</p>
+        </CardContent>
+      </Card>
+    )
+  }
+
   const ipChain = visit.ip?.split(',').map((ip: string) => ip.trim()) || visit.ip || null
 
   return (

--- a/components/cards/UrlOverview.tsx
+++ b/components/cards/UrlOverview.tsx
@@ -7,7 +7,7 @@ interface UrlOverviewProps {
   clicks: number
   createdAt: string
   updatedAt: string
-  latestVisit: UrlVisitInfo
+  latestVisit: UrlVisitInfo | null
 }
 
 export function UrlOverview({ clicks, createdAt, updatedAt, latestVisit }: UrlOverviewProps) {
@@ -55,9 +55,11 @@ export function UrlOverview({ clicks, createdAt, updatedAt, latestVisit }: UrlOv
           <div>
             <p className="text-sm text-muted-foreground">Last Visit</p>
             <p className="font-medium">
-              {formatDistanceToNow(new Date(latestVisit.createdAt), {
-                addSuffix: true
-              })}
+              {latestVisit
+                ? formatDistanceToNow(new Date(latestVisit.createdAt), {
+                    addSuffix: true
+                  })
+                : 'No visits yet'}
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- handle empty visit arrays in stats page
- allow null visits in `UrlOverview` and `LastVisit`
- display fallback messages when there are no visits

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run format:check` *(fails: cannot find package `prettier-plugin-tailwindcss`)*

------
https://chatgpt.com/codex/tasks/task_e_6878b8e37398832297d46f0357f778eb